### PR TITLE
設定画面の料金ページURLのリンク動作修正

### DIFF
--- a/lib/ui/setting/settings_page.dart
+++ b/lib/ui/setting/settings_page.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:line_icons/line_icon.dart';
 import 'package:line_icons/line_icons.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_web/url_launcher_web.dart';
 
 class SettingsPage extends StatelessWidget {
   const SettingsPage({super.key});
@@ -169,7 +169,10 @@ class _ViewUsageFeeLink extends StatelessWidget {
         padding: const EdgeInsets.only(left: 16),
         child: AppText.weblink('https://platform.openai.com/account/usage'),
       ),
-      onTap: () async => launchUrl(Uri.parse('https://platform.openai.com/account/usage')),
+      onTap: () async {
+        final launchPlugin = UrlLauncherPlugin();
+        await launchPlugin.launch('https://platform.openai.com/account/usage');
+      },
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -898,46 +898,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
-  url_launcher:
-    dependency: "direct main"
-    description:
-      name: url_launcher
-      sha256: "75f2846facd11168d007529d6cd8fcb2b750186bea046af9711f10b907e1587e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.10"
-  url_launcher_android:
-    dependency: transitive
-    description:
-      name: url_launcher_android
-      sha256: a52628068d282d01a07cd86e6ba99e497aa45ce8c91159015b2416907d78e411
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.27"
-  url_launcher_ios:
-    dependency: transitive
-    description:
-      name: url_launcher_ios
-      sha256: "9af7ea73259886b92199f9e42c116072f05ff9bea2dcb339ab935dfc957392c2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.4"
-  url_launcher_linux:
-    dependency: transitive
-    description:
-      name: url_launcher_linux
-      sha256: "206fb8334a700ef7754d6a9ed119e7349bc830448098f21a69bf1b4ed038cabc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.4"
-  url_launcher_macos:
-    dependency: transitive
-    description:
-      name: url_launcher_macos
-      sha256: "91ee3e75ea9dadf38036200c5d3743518f4a5eb77a8d13fda1ee5764373f185e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -947,21 +907,13 @@ packages:
     source: hosted
     version: "2.1.2"
   url_launcher_web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher_web
       sha256: "81fe91b6c4f84f222d186a9d23c73157dc4c8e1c71489c4d08be1ad3b228f1aa"
       url: "https://pub.dev"
     source: hosted
     version: "2.0.16"
-  url_launcher_windows:
-    dependency: transitive
-    description:
-      name: url_launcher_windows
-      sha256: a83ba3607a507758669cfafb03f9de09bf6e6280c14d9b9cb18f013e406dcacd
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,8 @@ dependencies:
 
   # other
   file_selector: ^0.9.2+4
-  url_launcher: ^6.1.10
+  # これUNLISTEDなのであまり使わない方がいいがurl_launchがFirebase HostingでPluginエラーになってしまうので仕方なくこちらを使う
+  url_launcher_web: ^2.0.16
   intl: ^0.17.0
   logger: ^1.2.2
 


### PR DESCRIPTION
Firebase Hostingにデプロイした後、リンクをタップしたらMissingPluginExceptionが発生してリンクページが開かなかった。  

調査の結果、Firebase Hostingにデプロイすると発生するらしくurl_launch_webを使うと問題なくなる。 webはアーカイブされていて使わない方がいいのだがとりあえず動くようにしたかったのでこちらで対応する。