### PR TITLE
systemの設定タイミングを会話の初回から任意に修正

### DIFF
--- a/lib/data/assist_repository.dart
+++ b/lib/data/assist_repository.dart
@@ -1,6 +1,7 @@
 import 'package:assistant_me/data/local/dao/talk_dao.dart';
 import 'package:assistant_me/data/remote/entities/gpt_image_request.dart';
 import 'package:assistant_me/data/remote/entities/gpt_request.dart';
+import 'package:assistant_me/data/remote/entities/gpt_response.dart';
 import 'package:assistant_me/data/remote/http_client.dart';
 import 'package:assistant_me/model/app_settings.dart';
 import 'package:assistant_me/model/talk.dart';
@@ -39,8 +40,9 @@ class AssistRepository {
 
     final response = await _ref.read(httpClientProvider).post(request);
 
-    // 【注意！】Threadには消費トークン数を保持する
-    // Talkには個々のTalkが使用したトークン数を保持する（APIからは合計トークンが返ってくるので差し引いて保存する）
+    // 注意！！
+    // ・Threadには消費トークン数を保持する
+    // ・Talkには個々のTalkが使用したトークン数を保持する（APIからは合計トークンが返ってくるので差し引いて保存する）
     final currentTotalTokenNum = historyTalks.map((e) => e.tokenNum).fold(0, (prev, e) => prev + e);
     final talk = Message.create(
       roleType: Talk.toRoleType(response.choices.first.message.role),
@@ -51,6 +53,7 @@ class AssistRepository {
     await _ref.read(talkDaoProvider).save(
           threadId: thread.id,
           message: message,
+          system: thread.system,
           talk: talk,
           currentTotalTokens: response.usage.totalTokens,
         );

--- a/lib/data/local/entities/talk_thread_entity.dart
+++ b/lib/data/local/entities/talk_thread_entity.dart
@@ -38,14 +38,14 @@ class TalkThreadEntity extends HiveObject {
   @HiveField(8, defaultValue: '')
   final String? system;
 
-  TalkThreadEntity updateTokenNum(int tokenNum) {
+  TalkThreadEntity copyWith({int? tokenNum, String? system}) {
     return TalkThreadEntity(
       id: id,
       title: title,
-      system: system,
+      system: system ?? this.system,
       createAt: createAt,
-      totalTalkTokenNum: totalTalkTokenNum + tokenNum,
-      currentTokenNum: tokenNum,
+      totalTalkTokenNum: (tokenNum != null) ? totalTalkTokenNum + tokenNum : totalTalkTokenNum,
+      currentTokenNum: tokenNum ?? currentTokenNum,
       llmModelName: llmModelName,
     );
   }

--- a/lib/model/talk_thread.dart
+++ b/lib/model/talk_thread.dart
@@ -36,6 +36,17 @@ class TalkThread {
   String get modelName => _llmModel.name;
 
   bool get isSettingSystem => (system != null) ? system!.isNotEmpty : false;
+
+  TalkThread updateSystem(String? system) {
+    return TalkThread(
+      id,
+      title,
+      system,
+      createAt,
+      _llmModel,
+      totalUseTokens,
+    );
+  }
 }
 
 // 現在の会話の消費トークン

--- a/lib/ui/history/history_page.dart
+++ b/lib/ui/history/history_page.dart
@@ -211,12 +211,11 @@ class _ViewThreadSystemRole extends ConsumerWidget {
       return const SizedBox();
     }
 
-    final system = currentThread.isSettingSystem ? currentThread.system! : 'この会話のSystemは未設定です。';
     return Container(
       alignment: Alignment.center,
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-        child: AppText.small(system),
+        child: (currentThread.isSettingSystem) ? AppText.small(currentThread.system!) : AppText.small('この会話のSystemは未設定です。', textColor: Colors.grey),
       ),
     );
   }

--- a/lib/ui/home/home_controller.dart
+++ b/lib/ui/home/home_controller.dart
@@ -26,13 +26,14 @@ class HomeController extends _$HomeController {
     final message = ref.read(homeTalkControllerProvider).text;
     final system = ref.read(homeSystemInputTextStateProvider);
 
-    // 最初の会話だったらスレッドを保存する
     if (ref.read(homeThreadProvider).noneTalk()) {
-      final newTread = await ref.read(assistRepositoryProvider).createThread(system: system, message: message);
-      ref.read(homeThreadProvider.notifier).state = newTread;
+      // 最初の会話だったらスレッドを保存する
+      final newThread = await ref.read(assistRepositoryProvider).createThread(system: system, message: message);
+      ref.read(homeThreadProvider.notifier).state = newThread;
+    } else {
+      // 継続会話であればこのタイミングでsystemのみ更新する
+      ref.read(homeThreadProvider.notifier).state = ref.read(homeThreadProvider).updateSystem(system);
     }
-
-    final thread = ref.read(homeThreadProvider);
 
     // ユーザーの会話追加
     ref.read(homeCurrentTalksProvider.notifier).addUserTalk(message);
@@ -41,6 +42,8 @@ class HomeController extends _$HomeController {
     // アシスタントのロード中会話追加
     ref.read(homeCurrentTalksProvider.notifier).addAssistantLoading();
     _autoScrollToEndOfTalkArea();
+
+    final thread = ref.read(homeThreadProvider);
 
     // アシスタント側の処理
     await _processAssistant(message, thread);

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -83,78 +83,6 @@ class _ViewSupportRow extends StatelessWidget {
   }
 }
 
-class _ViewTemplate extends ConsumerWidget {
-  const _ViewTemplate();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    const double widgetWidth = 300;
-
-    final isSelectDalle = ref.watch(homeIsSelectDallEModelProvider);
-    if (isSelectDalle) {
-      return const SizedBox();
-    }
-
-    final templates = ref.watch(templateNotifierProvider);
-    if (templates.isEmpty) {
-      return Container(
-        width: widgetWidth,
-        decoration: BoxDecoration(
-          borderRadius: const BorderRadius.all(Radius.circular(4)),
-          border: Border.all(width: 1, color: Colors.grey),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: AppText.normal('テンプレートは登録されていません'),
-        ),
-      );
-    }
-
-    return SizedBox(
-      width: widgetWidth,
-      child: ExpansionTile(
-        collapsedShape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(4)),
-          side: BorderSide(width: 1, color: Colors.grey),
-        ),
-        title: Row(
-          children: [
-            LineIcon(LineIcons.alternateFileAlt),
-            const SizedBox(width: 8),
-            AppText.normal('テンプレートを使う'),
-          ],
-        ),
-        expandedAlignment: Alignment.centerLeft,
-        expandedCrossAxisAlignment: CrossAxisAlignment.start,
-        children: templates.map((t) => _RowTemplate(t, width: widgetWidth)).toList(),
-      ),
-    );
-  }
-}
-
-class _RowTemplate extends ConsumerWidget {
-  const _RowTemplate(this.template, {required this.width});
-
-  final Template template;
-  final double width;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    return SizedBox(
-      width: width,
-      child: InkWell(
-        child: Padding(
-          padding: const EdgeInsets.all(8),
-          child: AppText.normal(template.title),
-        ),
-        onTap: () {
-          ref.read(homeControllerProvider.notifier).setTemplate(template.contents);
-        },
-      ),
-    );
-  }
-}
-
 class _ViewUseModel extends ConsumerWidget {
   const _ViewUseModel();
 
@@ -244,9 +172,7 @@ class _ViewInputSystem extends ConsumerWidget {
     }
 
     final systemInput = ref.watch(homeSystemInputTextStateProvider) ?? '';
-    final label = (systemInput.isNotEmpty) ? systemInput : 'Systemは未設定です(任意)';
-    // 一度会話を始めたらsystemの変更は抑止
-    final isStartTalk = ref.watch(homeCurrentTalksProvider).isNotEmpty;
+    final label = (systemInput.isNotEmpty) ? systemInput : 'Systemは未設定です。';
 
     return SizedBox(
       width: MediaQuery.of(context).size.width / 2,
@@ -255,7 +181,7 @@ class _ViewInputSystem extends ConsumerWidget {
           borderRadius: BorderRadius.all(Radius.circular(4)),
           side: BorderSide(width: 1, color: Colors.grey),
         ),
-        title: AppText.normal(label, overflow: TextOverflow.ellipsis, textColor: isStartTalk ? Colors.grey : null),
+        title: AppText.normal(label, overflow: TextOverflow.ellipsis),
         expandedAlignment: Alignment.centerLeft,
         expandedCrossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -263,12 +189,83 @@ class _ViewInputSystem extends ConsumerWidget {
             minLines: 1,
             maxLines: 5,
             initialValue: systemInput,
-            enabled: !isStartTalk,
             style: const TextStyle(fontSize: AppTheme.defaultTextSize),
             textAlignVertical: TextAlignVertical.top,
             onChanged: (String? value) => ref.read(homeControllerProvider.notifier).inputSystem(value),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _ViewTemplate extends ConsumerWidget {
+  const _ViewTemplate();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    const double widgetWidth = 300;
+
+    final isSelectDalle = ref.watch(homeIsSelectDallEModelProvider);
+    if (isSelectDalle) {
+      return const SizedBox();
+    }
+
+    final templates = ref.watch(templateNotifierProvider);
+    if (templates.isEmpty) {
+      return Container(
+        width: widgetWidth,
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.all(Radius.circular(4)),
+          border: Border.all(width: 1, color: Colors.grey),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: AppText.normal('テンプレートは登録されていません'),
+        ),
+      );
+    }
+
+    return SizedBox(
+      width: widgetWidth,
+      child: ExpansionTile(
+        collapsedShape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(4)),
+          side: BorderSide(width: 1, color: Colors.grey),
+        ),
+        title: Row(
+          children: [
+            LineIcon(LineIcons.alternateFileAlt),
+            const SizedBox(width: 8),
+            AppText.normal('テンプレートを使う'),
+          ],
+        ),
+        expandedAlignment: Alignment.centerLeft,
+        expandedCrossAxisAlignment: CrossAxisAlignment.start,
+        children: templates.map((t) => _RowTemplate(t, width: widgetWidth)).toList(),
+      ),
+    );
+  }
+}
+
+class _RowTemplate extends ConsumerWidget {
+  const _RowTemplate(this.template, {required this.width});
+
+  final Template template;
+  final double width;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SizedBox(
+      width: width,
+      child: InkWell(
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: AppText.normal(template.title),
+        ),
+        onTap: () {
+          ref.read(homeControllerProvider.notifier).setTemplate(template.contents);
+        },
       ),
     );
   }


### PR DESCRIPTION
systemの設定をなぜか会話の初回のみで実装してしまったので、会話の途中で変更したり設定することができなかった。  
よく考えたらこの仕様はおかしいので自由に設定できるようにした。  
ただ、会話の間にsystemを挟んで入れ子にするのは微妙かなと思ったので常にrequestのリストの一番上に設定することにした。